### PR TITLE
feat(LifeTime): Add life duration to GameObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>core</groupId>
     <artifactId>fromclasstogame</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>FromClassToGame</name>
     <description>Journey from a simple class to a Game, with the Java language</description>
     <inceptionYear>2021</inceptionYear>

--- a/src/main/java/fr/snapgames/fromclasstogame/core/entity/DebugViewportGrid.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/entity/DebugViewportGrid.java
@@ -1,0 +1,37 @@
+package fr.snapgames.fromclasstogame.core.entity;
+
+import fr.snapgames.fromclasstogame.core.physic.World;
+
+import java.util.List;
+
+public class DebugViewportGrid extends GameObject {
+    public int gridX;
+    public int gridY;
+    private World w;
+
+
+    public DebugViewportGrid(String objectName, World w) {
+        super(objectName);
+        this.w = w;
+        this.gridX = 16;
+        this.gridY = 16;
+    }
+
+    public DebugViewportGrid(String objectName, World w, int gridX, int gridY) {
+        super(objectName);
+        this.w = w;
+        this.gridX = gridX;
+        this.gridY = gridY;
+    }
+
+    @Override
+    public List<String> getDebugInfo() {
+        List<String> info = super.getDebugInfo();
+        info.add(String.format("world: %fx%f", w.width, w.height));
+        return info;
+    }
+
+    public World getWorld() {
+        return w;
+    }
+}

--- a/src/main/java/fr/snapgames/fromclasstogame/core/entity/GameObject.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/entity/GameObject.java
@@ -12,12 +12,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
 public class GameObject implements Entity {
 
 
     private static int index = 0;
     public int id = ++index;
     public String name = "noname_" + id;
+
+    public boolean active = true;
+
     public Vector2d position = new Vector2d();
     public Vector2d velocity = new Vector2d();
     public Vector2d acceleration = new Vector2d();
@@ -33,13 +37,10 @@ public class GameObject implements Entity {
     public double gravity = 0;
     public Material material;
     public double mass = 1;
-
+    public int life = -1;
     public List<Behavior<GameObject>> behaviors = new ArrayList<>();
-
     protected Map<String, Object> attributes = new HashMap<>();
-
     private List<String> debugData = new ArrayList<>();
-
     private int debug;
 
     public GameObject(String objectName) {
@@ -66,6 +67,14 @@ public class GameObject implements Entity {
     }
 
     public void update(long dt) {
+        if (life > -1) {
+            if (life - dt >= 0) {
+                life -= dt;
+            } else {
+                active = false;
+                life = -1;
+            }
+        }
     }
 
     public List<String> getDebugInfo() {
@@ -75,8 +84,8 @@ public class GameObject implements Entity {
         debugInfo.add("vel:" + velocity.toString());
         debugInfo.add("acc:" + acceleration.toString());
         debugInfo.add("friction:" + material.dynFriction);
-        debugInfo.add("contact:" + getAttribute("touching",false));
-        debugInfo.add("jumping:" + getAttribute("jumping",false));
+        debugInfo.add("contact:" + getAttribute("touching", false));
+        debugInfo.add("jumping:" + getAttribute("jumping", false));
         return debugInfo;
     }
 
@@ -179,6 +188,11 @@ public class GameObject implements Entity {
 
     public Map<String, Object> getAttributes() {
         return attributes;
+    }
+
+    public GameObject setDuration(int ms) {
+        this.life = ms;
+        return this;
     }
 
     public enum GOType {

--- a/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/AbstractRenderHelper.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/AbstractRenderHelper.java
@@ -13,6 +13,9 @@ import java.awt.image.BufferedImage;
  * @since 1.0.0
  */
 public class AbstractRenderHelper {
+    protected Color debugBackgroundColor = new Color(0.1f, 0.1f, 0.1f, 0.7f);
+    protected Color debugFrontColor = Color.ORANGE;
+    protected Color debugBoxColor = Color.YELLOW;
 
     /**
      * Simple set active Font

--- a/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/DebugViewportGridRenderHelper.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/DebugViewportGridRenderHelper.java
@@ -1,0 +1,34 @@
+package fr.snapgames.fromclasstogame.core.gfx.renderer;
+
+import fr.snapgames.fromclasstogame.core.entity.DebugViewportGrid;
+import fr.snapgames.fromclasstogame.core.physic.World;
+
+import java.awt.*;
+
+public class DebugViewportGridRenderHelper extends AbstractRenderHelper implements RenderHelper<DebugViewportGrid> {
+
+    private Color gridColor = Color.BLUE;
+
+    @Override
+    public String getType() {
+        return DebugViewportGrid.class.getName();
+    }
+
+    @Override
+    public void draw(Graphics2D g, DebugViewportGrid dvg) {
+        if (dvg.getWorld() != null && dvg.getDebug() > 0) {
+            World w = dvg.getWorld();
+            g.setColor(gridColor);
+            for (int x = 0; x < w.width; x += dvg.gridX) {
+                g.drawRect(x, 0, dvg.gridX, (int) w.height);
+            }
+            for (int y = 0; y < w.height; y += dvg.gridY) {
+                if (y + dvg.gridY < w.height) {
+                    g.drawRect(0, y, (int) w.width, dvg.gridY);
+                }
+            }
+            g.setColor(debugBoxColor);
+            g.drawRect(0, 0, (int) w.width, (int) w.height);
+        }
+    }
+}

--- a/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/GameObjectRenderHelper.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/GameObjectRenderHelper.java
@@ -9,9 +9,7 @@ import org.slf4j.LoggerFactory;
 public class GameObjectRenderHelper extends AbstractRenderHelper implements RenderHelper<GameObject> {
     private static final Logger logger = LoggerFactory.getLogger(GameObjectRenderHelper.class);
 
-    private Color debugBackgroundColor = new Color(0.1f, 0.1f, 0.1f, 0.7f);
-    private Color debugFrontColor = Color.ORANGE;
-    private Color debugBoxColor = Color.YELLOW;
+
 
     @Override
     public void draw(Graphics2D g, GameObject go) {
@@ -51,7 +49,7 @@ public class GameObjectRenderHelper extends AbstractRenderHelper implements Rend
                 setFontSize(g, 9);
                 double offsetY = -40;
                 double offsetX = go.width + 8;
-                int height = (int)((go.getDebugInfo().size()+2)*9);
+                int height = ((go.getDebugInfo().size()+2)*9);
                 fillRect(g, go.position, 100, height, go.width + 1, offsetY - 12, debugBackgroundColor);
                 setColor(g, debugFrontColor);
                 int i = 0;

--- a/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/TextRenderHelper.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/gfx/renderer/TextRenderHelper.java
@@ -1,16 +1,17 @@
 package fr.snapgames.fromclasstogame.core.gfx.renderer;
 
-import java.awt.Graphics2D;
+import java.awt.*;
 
 import fr.snapgames.fromclasstogame.core.entity.TextObject;
 
-public class TextRenderHelper implements RenderHelper<TextObject> {
+public class TextRenderHelper extends AbstractRenderHelper implements RenderHelper<TextObject> {
+    private Color shadowColor = new Color(0.2f,0.2f,0.2f,0.6f);
 
     @Override
     public void draw(Graphics2D g, TextObject to) {
-        g.setFont(to.font);
-        g.setColor(to.color);
-        g.drawString(to.text, (int) (to.position.x), (int) (to.position.y));
+        drawTextBorder(g,2,to);
+        setColor(g, to.color);
+        drawText(g,to.text,to.position);
     }
 
     @Override

--- a/src/main/java/fr/snapgames/fromclasstogame/core/physic/PhysicEngine.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/physic/PhysicEngine.java
@@ -58,11 +58,11 @@ public class PhysicEngine extends System {
 
             // limit acceleration with GameObject threshold `maxHorizontalAcceleration` and `maxVerticalAcceleration`
             if (go.getAttributes().containsKey("maxHorizontalAcceleration")) {
-                double ax = (Double) go.getAttribute("maxHorizontalAcceleration",0);
+                double ax = (Double) go.getAttribute("maxHorizontalAcceleration", 0);
                 go.acceleration.x = Math.abs(go.acceleration.x) > ax ? Math.signum(go.acceleration.x) * ax : go.acceleration.x;
             }
             if (go.getAttributes().containsKey("maxVerticalAcceleration")) {
-                double ay = (Double) go.getAttribute("maxVerticalAcceleration",0);
+                double ay = (Double) go.getAttribute("maxVerticalAcceleration", 0);
                 go.acceleration.y = Math.abs(go.acceleration.y) > ay ? Math.signum(go.acceleration.y) * ay : go.acceleration.y;
             }
 
@@ -71,25 +71,24 @@ public class PhysicEngine extends System {
             go.velocity = go.velocity.add(go.acceleration.multiply(dtCorrected)).multiply(friction);
 
             if (touching && Math.abs(go.acceleration.x) < 0.5 && Math.abs(go.acceleration.y) < 0.5) {
-                double dynFriction = dynFriction = go.material != null ? go.material.dynFriction : 1;
+                double dynFriction = go.material != null ? go.material.dynFriction : 1;
                 go.velocity = go.velocity.multiply(dynFriction);
             }
 
             // limit velocity with GameObject threshold `maxHorizontalVelocity` and `maxVerticalVelocity`
             if (go.getAttributes().containsKey("maxHorizontalVelocity")) {
-                double dx = (Double) go.getAttribute("maxHorizontalVelocity",0);
+                double dx = (Double) go.getAttribute("maxHorizontalVelocity", 0);
                 go.velocity.x = Math.abs(go.velocity.x) > dx ? Math.signum(go.velocity.x) * dx : go.velocity.x;
             }
             if (go.getAttributes().containsKey("maxVerticalVelocity")) {
-                double dy = (Double) go.getAttribute("maxVerticalVelocity",0);
+                double dy = (Double) go.getAttribute("maxVerticalVelocity", 0);
                 go.velocity.y = Math.abs(go.velocity.y) > dy ? Math.signum(go.velocity.y) * dy : go.velocity.y;
             }
             // Compute position
             go.position.x += ceilMinMaxValue(go.velocity.x * dtCorrected, 0.1, world.maxVelocity);
             go.position.y += ceilMinMaxValue(go.velocity.y * dtCorrected, 0.1, world.maxVelocity);
 
-            // Update the Object itself
-            go.update(dt);
+
             // test World space constrained
             verifyGameConstraint(go);
             // update Bounding box for this GameObject.
@@ -97,6 +96,8 @@ public class PhysicEngine extends System {
                 go.bbox.update(go);
             }
         }
+        // Update the Object itself
+        go.update(dt);
     }
 
     private double ceilValue(double x, double ceil) {

--- a/src/main/java/fr/snapgames/fromclasstogame/core/physic/collision/BoundingBox.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/core/physic/collision/BoundingBox.java
@@ -6,12 +6,12 @@ import fr.snapgames.fromclasstogame.core.physic.Vector2d;
 public class BoundingBox {
 
 
-    BoundingBoxType type;
-    Vector2d position;
-    Box shape;
-    double diam1;
-    double diam2;
-    Vector2d[] points;
+    public BoundingBoxType type;
+    public Vector2d position;
+    public Box shape;
+    public double diam1;
+    public double diam2;
+    public Vector2d[] points;
 
     public void update(GameObject go) {
         position.x = go.position.x;
@@ -41,7 +41,7 @@ public class BoundingBox {
         POINT,
         RECTANGLE,
         CIRCLE,
-        ELLIPSE;
+        ELLIPSE
     }
 
 }

--- a/src/main/java/fr/snapgames/fromclasstogame/demo/scenes/DemoScene.java
+++ b/src/main/java/fr/snapgames/fromclasstogame/demo/scenes/DemoScene.java
@@ -3,7 +3,9 @@ package fr.snapgames.fromclasstogame.demo.scenes;
 import fr.snapgames.fromclasstogame.core.Game;
 import fr.snapgames.fromclasstogame.core.behaviors.BasicParticleBehavior;
 import fr.snapgames.fromclasstogame.core.entity.Camera;
+import fr.snapgames.fromclasstogame.core.entity.DebugViewportGrid;
 import fr.snapgames.fromclasstogame.core.entity.GameObject;
+import fr.snapgames.fromclasstogame.core.entity.TextObject;
 import fr.snapgames.fromclasstogame.core.entity.particles.ParticleSystem;
 import fr.snapgames.fromclasstogame.core.exceptions.io.UnknownResource;
 import fr.snapgames.fromclasstogame.core.gfx.renderer.InventoryRenderHelper;
@@ -81,7 +83,17 @@ public class DemoScene extends AbstractScene {
 
     @Override
     public void create(Game g) throws UnknownResource {
-        g.setWorld(new World(800, 600));
+        // Declare World playground
+        World world = new World(800, 600);
+        g.setWorld(world);
+
+        // add Viewport Grid debug view
+        DebugViewportGrid dvg = new DebugViewportGrid("vpgrid", world, 32, 32);
+        dvg.setDebug(1);
+        dvg.setLayer(11);
+        dvg.setPriority(2);
+        add(dvg);
+
         // add main character (player)
         Material m = DefaultMaterial.newMaterial("player", 0.25, 0.3, 0.80, 0.98);
         GameObject player = new GameObject("player", new Vector2d(160, 100))
@@ -158,6 +170,13 @@ public class DemoScene extends AbstractScene {
         // shuffle `enemy_*`'s object's position and acceleration
         randomizeFilteredGameObject("enemy_");
 
+        TextObject welcome = new TextObject("welcomeMsg", new Vector2d(40, 100))
+                .setText("Welcome on Board");
+        welcome.setDuration(2000).setLayer(0).setPriority(1).relativeToCamera(true);
+
+        add(welcome);
+
+
         // Add the Debug switcher capability to this scene
         addBehavior(new DebugSwitcherBehavior());
 
@@ -172,7 +191,7 @@ public class DemoScene extends AbstractScene {
                     .setColor(Color.ORANGE).setImage(ResourceManager.getImage("images/tiles01.png:orangeBall"))
                     .setMaterial(DefaultMaterial.RUBBER.getMaterial()).setMass(Utils.rand(-8, 13)).setLayer(10)
                     .setPriority(3)
-                    .setSize(8,8);
+                    .setSize(8, 8);
 
             randomizePosAndAccGameObject(e);
             add(e);


### PR DESCRIPTION
- Add lifetime and active attributes to GameObject, and manage lifetime computation,
- Modify Render to manage active attribute on all GameObject (Simple a relative to camera),
- Modify PhysicEngine to manage the GameObject update process.
- Extract debug grid from Render system and create a DebugViewportGrid and a DebugViewportGridRenderHelper.
- prepare next release (1.0.1-SNAPSHOT)

Signed-off-by: Frédéric Delorme <frederic.delorme@gmail.com>